### PR TITLE
mention other IO::Path methods..

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ terms have a role `Temp::Path::AutoDel` role mixed in that will
 object the path points to.
 
 Note that deletion will happen only if the
-path was created by this module. For Example doing `make-temp-dir.sibling: 'foo'` will
+path was created by this module. For example doing `make-temp-dir.sibling: 'foo'` will
 still give you an `IO::Path` with `Temp::Path::AutoDel` mixed in due to how
 `IO::Path` methods create new objects. But new objects created by `.sibling`, `.add`,
 `.child`, `.parent`, etc won't be deleted, when the object gets garbage collected, because

--- a/README.md
+++ b/README.md
@@ -146,12 +146,13 @@ terms have a role `Temp::Path::AutoDel` role mixed in that will
 object the path points to.
 
 Note that deletion will happen only if the
-path was created by this module. Doing `make-temp-dir.sibling: 'foo'` will
+path was created by this module. For Example doing `make-temp-dir.sibling: 'foo'` will
 still give you an `IO::Path` with `Temp::Path::AutoDel` mixed in due to how
-`IO::Path` methods create new objects, but *that* new object created by
-'.sibling' won't be deleted, when the object gets garbage collected, because
-*you* created it and not the module. Of course, when the parent directory, that
-was crated by this module gets deleted, all the `.siblings` on disk get removed.
+`IO::Path` methods create new objects. But new objects created by `.sibling`, `.add`,
+`.child`, `.parent`, etc won't be deleted, when the object gets garbage collected, because
+*you* created it and not the module. Of course, when a parent directory, that 
+was crated by this module gets deleted, all its contents created `.child` on disk get removed.
+Siblings need to be removed manually.
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ still give you an `IO::Path` with `Temp::Path::AutoDel` mixed in due to how
 `IO::Path` methods create new objects. But new objects created by `.sibling`, `.add`,
 `.child`, `.parent`, etc won't be deleted, when the object gets garbage collected, because
 *you* created it and not the module. Of course, when a parent directory, that 
-was crated by this module gets deleted, all its contents created `.child` on disk get removed.
-Siblings need to be removed manually.
+was created by this module gets deleted, all its contents that you created with `.child`
+gets removed from the disk. Siblings need to be removed manually.
 
 ----
 


### PR DESCRIPTION
.. that create objects of IO::Path with the mixin.
Explain that `.siblings` need to be removed manually.